### PR TITLE
Fixed datagrid?.GetFilter().Clear for MultiplechoiceFilter

### DIFF
--- a/src/DataGridExtensions/MultipleChoiceFilter.cs
+++ b/src/DataGridExtensions/MultipleChoiceFilter.cs
@@ -229,9 +229,9 @@
         {
             var filter = Filter;
 
-            if (filter?.Items == null && _listBox?.IsLoaded == true)
+            if (filter?.Items == null)
             {
-                _listBox.SelectAll();
+                _listBox?.SelectAll();
             }
         }
 
@@ -247,10 +247,8 @@
 
             if (filter?.Items == null)
             {
-                if (listBox.IsLoaded)
-                {
-                    listBox.SelectAll();
-                }
+
+                listBox.SelectAll();
                 return;
             }
 
@@ -266,9 +264,6 @@
         private void ListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var listBox = (ListBox)sender;
-
-            if (!listBox.IsLoaded)
-                return;
 
             var selectedItems = listBox.SelectedItems.Cast<string>().ToArray();
 

--- a/src/DataGridExtensionsSample/Views/Customized2View.xaml
+++ b/src/DataGridExtensionsSample/Views/Customized2View.xaml
@@ -70,6 +70,8 @@
           <Decorator Width="10" />
           <Button x:Name="OpenAndPopulateAFilterButton" VerticalAlignment="Top" Padding="5,2" Command="{Binding OpenAndPopulateAFilterCommand}">Open &amp; Populate a Filter</Button>
           <Decorator Width="10" />
+          <Button x:Name="ClearFilter" VerticalAlignment="Top" Padding="5,2" Command="{Binding ClearFilterCommand}" CommandParameter="{Binding ElementName=DemoDataGrid}">Clear Filter</Button>
+          <Decorator Width="10" />
           <Button x:Name="ProgrammaticAccessToFilterControlButton" VerticalAlignment="Top" Padding="5,2" Command="{Binding ProgrammaticAccessToFilterControlCommand}">Change Popup Caption</Button>
         </StackPanel>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">

--- a/src/DataGridExtensionsSample/Views/Customized2ViewModel.cs
+++ b/src/DataGridExtensionsSample/Views/Customized2ViewModel.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.ComponentModel;
+    using System.Windows.Controls;
     using System.Windows.Input;
 
     using DataGridExtensions;
@@ -41,6 +42,14 @@
 #pragma warning disable CA1307 // Specify StringComparison for clarity => only supported in net5.0!
         public Predicate<object> GlobalFilter { get; } = item => (item as DataItem)?.Column1?.Contains('7') ?? false;
 #pragma warning restore CA1307 // Specify StringComparison for clarity
+
+
+        public ICommand ClearFilterCommand => new DelegateCommand<DataGrid>(ClearFilter);
+
+        private void ClearFilter(DataGrid? dataGrid)
+        {
+            dataGrid?.GetFilter().Clear();
+        }
 
         public ICommand ClearIpsumCommand => new DelegateCommand(ClearIpsum);
 


### PR DESCRIPTION
## "GetFilter().Clear" doesn't clear the Listbox of the MultiplechoiceFilters, which causes a UI which is not in sync with the DataGrid

**Problem:**
When clicking a Button which calls “datagrid?.GetFilter().Clear()” (example in Customized2), then the UI of the Pop Up doesn't update.


**Fix:**
Removing the “IsLoaded” if statements for the ListBox, which caused a return without an update of the MultipleChoiceFilter Listbox. 